### PR TITLE
Update prerequisites.md

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -2,7 +2,7 @@
 
 - **CentOS** (7.0+), **Debian** (9/Stretch+) or **Ubuntu** (16.04+) server. We only strive to support released stable versions of distributions, not betas or pre-releases. This playbook can take over your whole server or co-exist with other services that you have there.
 
-- [Python](https://www.python.org/) being installed on the server. Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python`).
+- [Python](https://www.python.org/)2 being installed on the server. Most distributions install Python by default, but some don't (e.g. Ubuntu 18.04) and require manual installation (something like `apt-get install python`).
 
 - a `cron`-like tool installed on the server such as `cron` or `anacron` to automatically schedule the Let's Encrypt SSL certificates. *This can be ignored if you use your own SSL certificates.*
 


### PR DESCRIPTION
I discovered setup would not run if only python 3 was installed on the server.  Maybe helpful with future distros?